### PR TITLE
fix continue-anyway bug after os.Args length check

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import "encoding/csv"
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: ", os.Args[0], "dirname")
+		os.Exit(-1)
 	}
 
 	path, err := filepath.Abs(os.Args[1])


### PR DESCRIPTION
Exit if no arguments are supplied. Avoids this error:

```
$ dstat
Usage:  dstat dirname
panic: runtime error: index out of range

goroutine 1 [running]:
main.main()
	/Users/ashatch/go/src/github.com/mikegolod/dstat/main.go:16 +0x76d
```